### PR TITLE
HOTFIX HOSTGROUPS

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,4 +1,4 @@
-[krb5_server]
+#[krb5_server]
 #<host>
 
 [utility_servers:children]

--- a/hosts
+++ b/hosts
@@ -1,4 +1,4 @@
-[krb5_server]
+#[krb5_server]
 <host>
 
 [utility_servers:children]

--- a/hosts
+++ b/hosts
@@ -1,9 +1,3 @@
-[scm_server]
-<host>
-
-[db_server]
-<host>
-
 [krb5_server]
 <host>
 

--- a/hosts
+++ b/hosts
@@ -1,5 +1,5 @@
-#[krb5_server]
-<host>
+[krb5_server]
+#<host>
 
 [utility_servers:children]
 scm_server

--- a/roles/cdh/tasks/main.yml
+++ b/roles/cdh/tasks/main.yml
@@ -1,7 +1,5 @@
 ---
 
-- include_vars: ../../../group_vars/cdh_servers.yml
-- include_vars: ../../../group_vars/db_server.yml
 
 # Check whether cluster already exists
 # https://cloudera.github.io/cm_api/apidocs/v13/path__clusters.html
@@ -16,14 +14,8 @@
     return_content: yes
   register: clusters_resp
 
-- set_fact:
-    cluster_exists: "{{ 'True' if clusters_resp.status == 200 else 'False' }}"
 
-- debug:
-    msg: "Cluster '{{ cluster_display_name }}' exists - {{ cluster_exists }}"
-    verbosity: 1
-
-- name: Discover product versions from parcel manifests
+- name: from parcel manifests discover product versions
   uri:
     url: "{{ item }}/manifest.json"
     status_code: 200


### PR DESCRIPTION
Certain hostgroups in the inventory file were
causing the playbook to fail. Narrowed down
on which hostgroups were the culprits and
removed them from the inventory file. Also
removed the associated vars that were included
in the cdh role.